### PR TITLE
Deutsche Übersetzung von "Help improve Nextcloud" angepasst.

### DIFF
--- a/l10n/de.js
+++ b/l10n/de.js
@@ -11,7 +11,7 @@ OC.L10N.register(
     "PHP environment <em>(version, memory limit, max. execution time, max. file size)</em>" : "PHP-Umgebung <em>(Version, Speichergrenze, Max. Ausführungszeit, Max. Dateigröße)</em>",
     "Server instance details <em>(version, memcache used, status of locking/previews/avatars)</em>" : "Details zur Server-Instanz <em>(Version, Wird Memcache verwendet?, Sind Sperren/Vorschau/Avatare aktiviert?)</em>",
     "Statistic <em>(number of: files, users, storages per type, comments and tags)</em>" : "Statistik <em>(Anzahl von: Dateien, Benutzern, Speicher pro Typ, Kommentare und Schlagworte)</em>",
-    "Help improve Nextcloud" : "Helfe Nextcloud zu verbessern",
+    "Help improve Nextcloud" : "Hilf Nextcloud zu verbessern",
     "Do you want to help us to improve Nextcloud by providing some anonymized data about your setup and usage? You can disable it at any time in the admin settings again." : "Möchtest Du uns helfen Nextcloud zu verbessern? Das kannst Du durch Übertragen von anonymisierten Daten von Deinen Einstellungen und Nutzung. Du kannst dies jederzeit in den Administrationseinstellungen deaktivieren.",
     "Not now" : "Nicht jetzt",
     "Send usage" : "Nutzung senden",

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -9,7 +9,7 @@
     "PHP environment <em>(version, memory limit, max. execution time, max. file size)</em>" : "PHP-Umgebung <em>(Version, Speichergrenze, Max. Ausführungszeit, Max. Dateigröße)</em>",
     "Server instance details <em>(version, memcache used, status of locking/previews/avatars)</em>" : "Details zur Server-Instanz <em>(Version, Wird Memcache verwendet?, Sind Sperren/Vorschau/Avatare aktiviert?)</em>",
     "Statistic <em>(number of: files, users, storages per type, comments and tags)</em>" : "Statistik <em>(Anzahl von: Dateien, Benutzern, Speicher pro Typ, Kommentare und Schlagworte)</em>",
-    "Help improve Nextcloud" : "Helfe Nextcloud zu verbessern",
+    "Help improve Nextcloud" : "Hilf Nextcloud zu verbessern",
     "Do you want to help us to improve Nextcloud by providing some anonymized data about your setup and usage? You can disable it at any time in the admin settings again." : "Möchtest Du uns helfen Nextcloud zu verbessern? Das kannst Du durch Übertragen von anonymisierten Daten von Deinen Einstellungen und Nutzung. Du kannst dies jederzeit in den Administrationseinstellungen deaktivieren.",
     "Not now" : "Nicht jetzt",
     "Send usage" : "Nutzung senden",


### PR DESCRIPTION
Der Imperativ von "helfen" lautet "hilf".