### PR TITLE
fix: notifications link for mobile / desktop error generating errors in v30

### DIFF
--- a/lib/BackgroundJobs/AdminNotification.php
+++ b/lib/BackgroundJobs/AdminNotification.php
@@ -36,15 +36,17 @@ class AdminNotification extends QueuedJob {
 			->setSubject('updated')
 			->setObject('dummy', '23');
 
+		$enableLink = $this->url->linkToOCSRouteAbsolute('survey_client.Endpoint.enableMonthly');
 		$enableAction = $notification->createAction();
 		$enableAction->setLabel('enable')
-			->setLink($this->url->getAbsoluteURL('ocs/v2.php/apps/survey_client/api/v1/monthly'), 'POST')
+			->setLink($enableLink, 'POST')
 			->setPrimary(true);
 		$notification->addAction($enableAction);
 
+		$disableLink = $this->url->linkToOCSRouteAbsolute('survey_client.Endpoint.disableMonthly');
 		$disableAction = $notification->createAction();
 		$disableAction->setLabel('disable')
-			->setLink($this->url->getAbsoluteURL('ocs/v2.php/apps/survey_client/api/v1/monthly'), 'DELETE')
+			->setLink($disableLink, 'DELETE')
 			->setPrimary(false);
 		$notification->addAction($disableAction);
 


### PR DESCRIPTION
Fixes #316

EDIT: I guess this has been broken for awhile, but wasn't super apparent until the new notification logging added in nextcloud/server#44770