### PR TITLE
admin ui: fix checkbox toggles not working

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -11,7 +11,7 @@ $(document).ready(function() {
 		OCP.AppConfig.setValue(
 			'survey_client',
 			$(this).attr('name').substring(14),
-			$(this).attr('checked') ? 'yes' : 'no',
+			$(this).prop('checked') ? 'yes' : 'no',
 			{
 				success: function() {
 					$button.attr('disabled', false);
@@ -26,7 +26,7 @@ $(document).ready(function() {
 
 		$.ajax({
 			url: OC.linkToOCS('apps/survey_client/api/v1', 2) + 'monthly?format=json',
-			type: $(this).attr('checked') ? 'POST' : 'DELETE',
+			type: $(this).prop('checked') ? 'POST' : 'DELETE',
 			success: function() {
 				$button.attr('disabled', false);
 			}


### PR DESCRIPTION
Since jQuery 1.6 the attr() and prop() functions more strictly follow W3C forms specification. Concretely the following is the current functionality without going to deep into details:

* attr('checked') will actually check defaultChecked, which is the initial state of the checkbox upon page load.
* prop('checked') matches the current state of the checkbox. It will change state when the user checks or unchecks the checkbox.

https://api.jquery.com/attr/
https://api.jquery.com/prop/

Concretely current implementation is broken since probably jQuery 1.6 as observed in devtools requests. The requests when toggling checkboxes are always sending the on-page-load current value. So if a setting is on all toggles of the checkbox will always turn the setting on server-side, making it impossible to actually change the setting.

Switch to prop() function to resolve the issue.

Fixes https://github.com/nextcloud/survey_client/issues/121 Fixes https://github.com/nextcloud/survey_client/issues/166 Fixes https://github.com/nextcloud/survey_client/issues/305