### PR TITLE
Use SPDX license identifier

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@
 	</description>
 
 	<version>7.0.0-dev.0</version>
-	<licence>agpl</licence>
+	<licence>AGPL-3.0-or-later</licence>
 	<author>Björn Schiessle</author>
 	<author>Joas Schilling</author>
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 	},
 	"name": "nextcloud/survey_client",
 	"description": "Usage survey",
-	"license": "AGPL",
+	"license": "AGPL-3.0-or-later",
 	"require-dev": {
 		"nextcloud/coding-standard": "^1.4.0",
 		"vimeo/psalm": "^6.16.1",


### PR DESCRIPTION
unifying the license string, already used in package.json and supported in info.xml since 31, so no issue given min-version is set to 35 at the moment.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
